### PR TITLE
fix .read_msg_addr()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,26 @@
-# Description
+# TONsdk
+[![PyPI](https://img.shields.io/pypi/v/tonsdk?color=blue)](https://pypi.org/project/tonsdk/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/tonsdk)](https://pypi.org/project/tonsdk/)
+[![Downloads](https://static.pepy.tech/badge/tonsdk)](https://pepy.tech/project/tonsdk)
 
-Analogue of the [tonweb js](https://github.com/toncenter/tonweb) library. Feel free to use their docs and examples.
+## Description
+This low-level Python library allows you to work with the [TON blockchain](https://ton.org/).
 
-# Notes
+### Notes
 
 - tonsdk/provider part is dirty.
 
-# Installation
+## How to install
 
-```code
-$ pip install tonsdk
+```bash
+pip install tonsdk
 ```
 
-# Usage examples
+## How to use
 
+You can find examples in [examples](https://github.com/tonfactory/tonsdk/tree/master/examples) folder
+
+## General usage examples
 ### Create mnemonic, init wallet class, create external message to deploy the wallet
 
 ```python
@@ -81,93 +88,6 @@ Base64boc to transfer the jettons: {}
 """.format(nft_boc, jettons_boc))
 ```
 
-### MultiSig Wallet
-#### Off-chain signatures
-```python
-from tonsdk.contract.wallet import MultiSigWallet, MultiSigOrder, MultiSigOrderBuilder
-from tonsdk.crypto import mnemonic_new, mnemonic_to_wallet_key
-from tonsdk.utils import Address, bytes_to_b64str, b64str_to_bytes, to_nano
-
-# mnemonics1 = mnemonic_new()
-# mnemonics2 = mnemonic_new()
-# mnemonics3 = mnemonic_new()
-mnemonics1 = ['broken', 'decade', 'unit', 'bird', 'enrich', 'great', 'nurse', 'offer', 'rescue', 'sound', 'pole', 'true', 'dignity', 'buyer', 'provide', 'boil', 'connect', 'universe', 'model', 'add', 'obtain', 'hire', 'gift', 'swim']
-mnemonics2 = ['rather', 'voice', 'zone', 'fold', 'rotate', 'crane', 'roast', 'brave', 'motor', 'kid', 'note', 'squirrel', 'piece', 'home', 'expose', 'bench', 'flame', 'wood', 'person', 'assist', 'vocal', 'bomb', 'dismiss', 'diesel']
-mnemonics3 = ['author', 'holiday', 'figure', 'luxury', 'leg', 'fringe', 'sibling', 'citizen', 'enforce', 'convince', 'silly', 'girl', 'remove', 'purity', 'sand', 'paper', 'file', 'review', 'window', 'kite', 'illegal', 'allow', 'satisfy', 'wait']
-
-pub_k0, priv_k0 = mnemonic_to_wallet_key(mnemonics1)
-pub_k1, priv_k1 = mnemonic_to_wallet_key(mnemonics2)
-pub_k2, priv_k2 = mnemonic_to_wallet_key(mnemonics3)
-
-wallet = MultiSigWallet(public_keys=[pub_k0, pub_k1, pub_k2], k=2, wallet_id=0)
-
-print(wallet.address.to_string(True, True, True))  # EQCOpgZNmHhDe4nuZY6aQh3sgqgwgTBtCL4kZPYTDTDlZY_Y
-query = wallet.create_init_external_message()
-init_boc = bytes_to_b64str(query["message"].to_boc(False))
-print('Base64boc to deploy the wallet: ', init_boc)
-
-order1 = MultiSigOrderBuilder(wallet.options["wallet_id"])
-order1.add_message(to_addr='EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N', amount=to_nano('0.01', 'ton'), send_mode=3, payload='hello from python tonsdk')
-order1b = order1.build()
-
-order1b.sign(0, priv_k0)
-order1b.sign(1, priv_k1)
-
-query = wallet.create_transfer_message(order1b, priv_k2)
-transfer_boc = bytes_to_b64str(query["message"].to_boc(False))
-print('Base64boc to transfer tons: ', transfer_boc)
-
-```
-#### On-chain signatures
-```python
-from tonsdk.contract.wallet import MultiSigWallet, MultiSigOrder, MultiSigOrderBuilder
-from tonsdk.crypto import mnemonic_new, mnemonic_to_wallet_key, verify_sign
-from tonsdk.utils import Address, bytes_to_b64str, b64str_to_bytes, to_nano, sign_message
-
-# mnemonics1 = mnemonic_new()
-# mnemonics2 = mnemonic_new()
-# mnemonics3 = mnemonic_new()
-mnemonics1 = ['broken', 'decade', 'unit', 'bird', 'enrich', 'great', 'nurse', 'offer', 'rescue', 'sound', 'pole', 'true', 'dignity', 'buyer', 'provide', 'boil', 'connect', 'universe', 'model', 'add', 'obtain', 'hire', 'gift', 'swim']
-mnemonics2 = ['rather', 'voice', 'zone', 'fold', 'rotate', 'crane', 'roast', 'brave', 'motor', 'kid', 'note', 'squirrel', 'piece', 'home', 'expose', 'bench', 'flame', 'wood', 'person', 'assist', 'vocal', 'bomb', 'dismiss', 'diesel']
-mnemonics3 = ['author', 'holiday', 'figure', 'luxury', 'leg', 'fringe', 'sibling', 'citizen', 'enforce', 'convince', 'silly', 'girl', 'remove', 'purity', 'sand', 'paper', 'file', 'review', 'window', 'kite', 'illegal', 'allow', 'satisfy', 'wait']
-pub_k0, priv_k0 = mnemonic_to_wallet_key(mnemonics1)
-pub_k1, priv_k1 = mnemonic_to_wallet_key(mnemonics2)
-pub_k2, priv_k2 = mnemonic_to_wallet_key(mnemonics3)
-
-wallet = MultiSigWallet(public_keys=[pub_k0, pub_k1, pub_k2], k=2, wallet_id=0)
-
-order1 = MultiSigOrderBuilder(wallet.options["wallet_id"])
-message = order1.add_message(to_addr='EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N', amount=to_nano('0.01', 'ton'), send_mode=3, payload='hello from python tonsdk')
-query_id = order1.query_id
-
-order1b = order1.build()
-order1b.sign(0, priv_k0)
-
-query = wallet.create_transfer_message(order1b, priv_k0)
-transfer_boc = bytes_to_b64str(query["message"].to_boc(False))
-
-print(transfer_boc)
-
-
-"""wait for transaction processing"""
-
-
-order2 = MultiSigOrderBuilder(wallet.options["wallet_id"], query_id=query_id)
-
-order2.add_message_from_cell(message)
-# order2.add_message(to_addr='EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N', amount=to_nano('0.01', 'ton'),
-#                    send_mode=3, payload='hello from python tonsdk')
-
-
-order2b = order2.build()
-order2b.sign(1, priv_k1)
-
-query_2 = wallet.create_transfer_message(order2b, priv_k1)
-transfer_boc_2 = bytes_to_b64str(query_2["message"].to_boc(False))
-
-print(transfer_boc_2)
-
-```
 ### Clients usage example (dirty)
 
 *Note - to use these clients you should install tvm_valuetypes and aiohttp packages*

--- a/examples/tokens/jetton/mint.py
+++ b/examples/tokens/jetton/mint.py
@@ -1,0 +1,85 @@
+from tonsdk.contract.token.ft import JettonMinter, JettonWallet
+from tonsdk.contract import Address
+from tonsdk.utils import to_nano, bytes_to_b64str
+from tonsdk.contract.wallet import Wallets, WalletVersionEnum
+
+
+def create_jetton_minter():
+    minter = JettonMinter(admin_address=Address('admin address'),
+                          jetton_content_uri='https://raw.githubusercontent.com/yungwine/pyton-lessons/master/lesson-6/token_data.json',
+                          jetton_wallet_code_hex=JettonWallet.code)
+
+    return minter
+
+
+def create_mint_body():
+    minter = create_jetton_minter()
+
+    body = minter.create_mint_body(destination=Address('address'),
+                                   jetton_amount=to_nano(int('mint amount'), 'ton'))
+    return body
+
+
+def create_change_owner_body():
+    minter = create_jetton_minter()
+
+    body = minter.create_change_admin_body(
+        new_admin_address=Address('EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c'))
+    return body
+
+
+def create_burn_body():
+    body = JettonWallet().create_burn_body(
+        jetton_amount=to_nano(int('burn amount'), 'ton'))
+    return body
+
+
+"""your wallet mnemonics"""
+mnemonics = ['always', 'crystal', 'grab', 'glance', 'cause', 'dismiss', 'answer', 'expose', 'once', 'session',
+             'tunnel', 'topic', 'defense', 'such', 'army', 'smile', 'exhibit', 'misery', 'runway', 'tone', 'want',
+             'primary', 'piano', 'language']
+
+mnemonics, pub_k, priv_k, wallet = Wallets.from_mnemonics(mnemonics=mnemonics, version=WalletVersionEnum.v3r2,
+                                                          workchain=0)
+
+"""deploy jetton minter"""
+minter = create_jetton_minter()
+collection_state_init = minter.create_state_init()['state_init']
+
+query = wallet.create_transfer_message(to_addr=minter.address.to_string(),
+                                       amount=to_nano(0.02, 'ton'),
+                                       state_init=collection_state_init,
+                                       seqno=int('wallet seqno'))
+
+
+"""mint tokens"""
+body = create_mint_body()
+minter = create_jetton_minter()
+
+query = wallet.create_transfer_message(to_addr=minter.address.to_string(),
+                                       amount=to_nano(0.04, 'ton'),
+                                       seqno=int('wallet seqno'),
+                                       payload=body)
+
+
+"""change owner address"""
+body = create_change_owner_body()
+minter = create_jetton_minter()
+
+query = wallet.create_transfer_message(to_addr=minter.address.to_string(),
+                                       amount=to_nano(0.04, 'ton'),
+                                       seqno=int('wallet seqno'),
+                                       payload=body)
+
+
+"""burn tokens"""
+body = create_burn_body()
+
+query = wallet.create_transfer_message(to_addr='address of your jetton wallet',
+                                       amount=to_nano(0.04, 'ton'),
+                                       seqno=int('wallet seqno'),
+                                       payload=body)
+
+
+"""then send boc to blockchain"""
+boc = bytes_to_b64str(query["message"].to_boc(False))

--- a/examples/tokens/jetton/transfer.py
+++ b/examples/tokens/jetton/transfer.py
@@ -1,0 +1,26 @@
+from tonsdk.contract.token.ft import JettonWallet
+from tonsdk.utils import to_nano, bytes_to_b64str, Address
+from tonsdk.contract.wallet import Wallets, WalletVersionEnum
+
+
+"""your wallet mnemonics"""
+mnemonics = ['always', 'crystal', 'grab', 'glance', 'cause', 'dismiss', 'answer', 'expose', 'once', 'session',
+             'tunnel', 'topic', 'defense', 'such', 'army', 'smile', 'exhibit', 'misery', 'runway', 'tone', 'want',
+             'primary', 'piano', 'language']
+mnemonics, pub_k, priv_k, wallet = Wallets.from_mnemonics(mnemonics=mnemonics, version=WalletVersionEnum.v3r2,
+                                                          workchain=0)
+
+
+"""transfer"""
+body = JettonWallet().create_transfer_body(
+        to_address=Address('address'),
+        jetton_amount=to_nano(float('jettons amount'), 'ton'),
+    )
+
+query = wallet.create_transfer_message(to_addr='your jetton wallet address',
+                                       amount=to_nano(0.1, 'ton'),
+                                       seqno=int('wallet seqno'),
+                                       payload=body)
+
+"""then send boc to blockchain"""
+boc = bytes_to_b64str(query["message"].to_boc(False))

--- a/examples/tokens/nft/mint.py
+++ b/examples/tokens/nft/mint.py
@@ -1,0 +1,96 @@
+from tonsdk.contract.token.nft import NFTCollection, NFTItem
+from tonsdk.contract import Address
+from tonsdk.utils import to_nano, bytes_to_b64str
+from tonsdk.contract.wallet import Wallets, WalletVersionEnum
+
+
+def create_collection():
+    royalty_base = 1000
+    royalty_factor = 55
+
+    #  royalty in percents = royalty_factor / royalty_base
+
+    collection = NFTCollection(royalty_base=royalty_base,
+                               royalty=royalty_factor,
+                               royalty_address=Address('royalty address'),
+                               owner_address=Address('collection owner address'),
+                               collection_content_uri='https://s.getgems.io/nft/b/c/62fba50217c3fe3cbaad9e7f/meta.json',
+                               nft_item_content_base_uri='https://s.getgems.io/nft/b/c/62fba50217c3fe3cbaad9e7f/',
+                               nft_item_code_hex=NFTItem.code)
+
+    return collection
+
+
+def create_nft_mint_body():
+    collection = create_collection()
+
+    nft_item_index = 0
+    # in most collections with offchain metadata individual item content uri = item_index/meta.json
+
+    body = collection.create_mint_body(item_index=nft_item_index,
+                                       new_owner_address=Address('owner address'),
+                                       item_content_uri=f'{nft_item_index}/meta.json',
+                                       amount=to_nano(0.02, 'ton'))
+
+    return body
+
+
+def create_batch_nft_mint_body():
+    collection = create_collection()
+
+    contents_and_owners = []
+
+    from_item_index = 1
+    to_item_index = 11
+
+    for i in range(from_item_index, to_item_index + 1):
+        contents_and_owners.append(
+            (f'{i}/meta.json', Address('owner address'))
+        )
+
+    body = collection.create_batch_mint_body(from_item_index=from_item_index,
+                                             contents_and_owners=contents_and_owners,
+                                             amount_per_one=to_nano(0.01, 'ton'))
+    return body
+
+
+"""your wallet mnemonics"""
+mnemonics = ['always', 'crystal', 'grab', 'glance', 'cause', 'dismiss', 'answer', 'expose', 'once', 'session',
+             'tunnel', 'topic', 'defense', 'such', 'army', 'smile', 'exhibit', 'misery', 'runway', 'tone', 'want',
+             'primary', 'piano', 'language']
+
+mnemonics, pub_k, priv_k, wallet = Wallets.from_mnemonics(mnemonics=mnemonics, version=WalletVersionEnum.v3r2,
+                                                          workchain=0)
+
+"""deploy collection"""
+collection = create_collection()
+collection_state_init = collection.create_state_init()['state_init']
+
+query = wallet.create_transfer_message(to_addr=collection.address.to_string(),
+                                       amount=to_nano(0.02, 'ton'),
+                                       state_init=collection_state_init,
+                                       seqno=int('wallet seqno'))
+
+
+"""mint nft"""
+body = create_nft_mint_body()
+collection = create_collection()
+
+query = wallet.create_transfer_message(to_addr=collection.address.to_string(),
+                                       amount=to_nano(0.04, 'ton'),
+                                       seqno=int('wallet seqno'),
+                                       payload=body)
+
+
+"""mint batch of nfts"""
+body = create_batch_nft_mint_body()
+collection = create_collection()
+
+query = wallet.create_transfer_message(to_addr=collection.address.to_string(),
+                                       amount=to_nano(0.04, 'ton'),
+                                       seqno=int('wallet seqno'),
+                                       payload=body)
+
+
+"""then send boc to blockchain"""
+boc = bytes_to_b64str(query["message"].to_boc(False))

--- a/examples/tokens/nft/transfer.py
+++ b/examples/tokens/nft/transfer.py
@@ -1,0 +1,22 @@
+from tonsdk.contract.token.nft import NFTItem
+from tonsdk.utils import to_nano, bytes_to_b64str, Address
+from tonsdk.contract.wallet import Wallets, WalletVersionEnum
+
+
+"""your wallet mnemonics"""
+mnemonics = ['always', 'crystal', 'grab', 'glance', 'cause', 'dismiss', 'answer', 'expose', 'once', 'session',
+             'tunnel', 'topic', 'defense', 'such', 'army', 'smile', 'exhibit', 'misery', 'runway', 'tone', 'want',
+             'primary', 'piano', 'language']
+mnemonics, pub_k, priv_k, wallet = Wallets.from_mnemonics(mnemonics=mnemonics, version=WalletVersionEnum.v3r2,
+                                                          workchain=0)
+
+
+"""transfer"""
+body = NFTItem().create_transfer_body(new_owner_address=Address('new owner address'))
+query = wallet.create_transfer_message(to_addr='nft addr',
+                                       amount=to_nano(0.1, 'ton'),
+                                       seqno=int('wallet seqno'),
+                                       payload=body)
+
+"""then send boc to blockchain"""
+boc = bytes_to_b64str(query["message"].to_boc(False))

--- a/examples/types/cell.py
+++ b/examples/types/cell.py
@@ -1,0 +1,7 @@
+from tonsdk.boc import begin_cell, Cell
+from tonsdk.utils import Address
+
+cell = begin_cell()\
+    .store_uint(4, 32)\
+    .store_address(Address('EQBvW8Z5huBkMJYdnfAEM5JqTNkuWX3diqYENkWsIL0XggGG'))\
+    .end_cell()

--- a/examples/types/slice.py
+++ b/examples/types/slice.py
@@ -1,0 +1,16 @@
+from tonsdk.boc import Slice, begin_cell
+from tonsdk.utils import Address
+
+cell = begin_cell()\
+    .store_uint(4, 32)\
+    .store_address(Address('EQBvW8Z5huBkMJYdnfAEM5JqTNkuWX3diqYENkWsIL0XggGG'))\
+    .end_cell()
+
+slice = cell.begin_parse()  # or Slice(cell)
+
+stored_value_uint = slice.read_uint(32)
+
+stored_value_addr = slice.read_msg_addr()
+
+assert stored_value_uint == 4
+assert stored_value_addr.to_string(True, True, True) == 'EQBvW8Z5huBkMJYdnfAEM5JqTNkuWX3diqYENkWsIL0XggGG'

--- a/examples/wallets/highload.py
+++ b/examples/wallets/highload.py
@@ -1,0 +1,34 @@
+from tonsdk.contract.wallet import WalletVersionEnum, Wallets
+from tonsdk.utils import Address, bytes_to_b64str, b64str_to_bytes, to_nano
+
+mnemonics = []
+_mnemonics, _pub_k, _priv_k, wallet = Wallets.from_mnemonics(
+    mnemonics, WalletVersionEnum('hv2'), 0)
+
+query = wallet.create_init_external_message()
+base64_boc = bytes_to_b64str(query["message"].to_boc(False))
+
+recieps = [
+    {
+        'address': 'destination address',
+        'payload': 'comment',
+        'amount': to_nano(float('amount'), 'ton'),
+        'send_mode': 3
+    },
+    {
+        'address': 'destination address',
+        'payload': 'comment',
+        'amount': to_nano(float('amount'), 'ton'),
+        'send_mode': 3
+    },
+    {
+        'address': 'destination address',
+        'payload': 'comment',
+        'amount': to_nano(float('amount'), 'ton'),
+        'send_mode': 3
+    },
+]
+
+query = wallet.create_transfer_message(recipients_list=recieps, query_id=0)
+
+boc = bytes_to_b64str(query["message"].to_boc(False))  # send this boc to blockchain

--- a/examples/wallets/multisig/deploy.py
+++ b/examples/wallets/multisig/deploy.py
@@ -1,0 +1,26 @@
+from tonsdk.contract.wallet import MultiSigWallet, MultiSigOrder, MultiSigOrderBuilder
+from tonsdk.crypto import mnemonic_new, mnemonic_to_wallet_key
+from tonsdk.utils import Address, bytes_to_b64str, b64str_to_bytes, to_nano
+
+
+"""import or generate mnemonics"""
+# mnemonics1 = mnemonic_new()
+# mnemonics2 = mnemonic_new()
+# mnemonics3 = mnemonic_new()
+mnemonics1 = ['broken', 'decade', 'unit', 'bird', 'enrich', 'great', 'nurse', 'offer', 'rescue', 'sound', 'pole', 'true', 'dignity', 'buyer', 'provide', 'boil', 'connect', 'universe', 'model', 'add', 'obtain', 'hire', 'gift', 'swim']
+mnemonics2 = ['rather', 'voice', 'zone', 'fold', 'rotate', 'crane', 'roast', 'brave', 'motor', 'kid', 'note', 'squirrel', 'piece', 'home', 'expose', 'bench', 'flame', 'wood', 'person', 'assist', 'vocal', 'bomb', 'dismiss', 'diesel']
+mnemonics3 = ['author', 'holiday', 'figure', 'luxury', 'leg', 'fringe', 'sibling', 'citizen', 'enforce', 'convince', 'silly', 'girl', 'remove', 'purity', 'sand', 'paper', 'file', 'review', 'window', 'kite', 'illegal', 'allow', 'satisfy', 'wait']
+
+
+"""get pub and priv keys from mnemonics"""
+pub_k0, priv_k0 = mnemonic_to_wallet_key(mnemonics1)
+pub_k1, priv_k1 = mnemonic_to_wallet_key(mnemonics2)
+pub_k2, priv_k2 = mnemonic_to_wallet_key(mnemonics3)
+
+
+wallet = MultiSigWallet(public_keys=[pub_k0, pub_k1, pub_k2], k=2, wallet_id=0)  # k arg means required amount of signs
+
+
+query = wallet.create_init_external_message()
+init_boc = bytes_to_b64str(query["message"].to_boc(False))
+print('Base64boc to deploy the wallet: ', init_boc)

--- a/examples/wallets/multisig/offchain_signatures.py
+++ b/examples/wallets/multisig/offchain_signatures.py
@@ -1,0 +1,36 @@
+from tonsdk.contract.wallet import MultiSigWallet, MultiSigOrder, MultiSigOrderBuilder
+from tonsdk.crypto import mnemonic_new, mnemonic_to_wallet_key
+from tonsdk.utils import Address, bytes_to_b64str, b64str_to_bytes, to_nano
+
+
+"""import or generate mnemonics"""
+# mnemonics1 = mnemonic_new()
+# mnemonics2 = mnemonic_new()
+# mnemonics3 = mnemonic_new()
+mnemonics1 = ['broken', 'decade', 'unit', 'bird', 'enrich', 'great', 'nurse', 'offer', 'rescue', 'sound', 'pole', 'true', 'dignity', 'buyer', 'provide', 'boil', 'connect', 'universe', 'model', 'add', 'obtain', 'hire', 'gift', 'swim']
+mnemonics2 = ['rather', 'voice', 'zone', 'fold', 'rotate', 'crane', 'roast', 'brave', 'motor', 'kid', 'note', 'squirrel', 'piece', 'home', 'expose', 'bench', 'flame', 'wood', 'person', 'assist', 'vocal', 'bomb', 'dismiss', 'diesel']
+mnemonics3 = ['author', 'holiday', 'figure', 'luxury', 'leg', 'fringe', 'sibling', 'citizen', 'enforce', 'convince', 'silly', 'girl', 'remove', 'purity', 'sand', 'paper', 'file', 'review', 'window', 'kite', 'illegal', 'allow', 'satisfy', 'wait']
+
+
+"""get pub and priv keys from mnemonics"""
+pub_k0, priv_k0 = mnemonic_to_wallet_key(mnemonics1)
+pub_k1, priv_k1 = mnemonic_to_wallet_key(mnemonics2)
+pub_k2, priv_k2 = mnemonic_to_wallet_key(mnemonics3)
+
+
+wallet = MultiSigWallet(public_keys=[pub_k0, pub_k1, pub_k2], k=2, wallet_id=0)
+
+
+"""create order and add message"""
+order1 = MultiSigOrderBuilder(wallet.options["wallet_id"])
+order1.add_message(to_addr='EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N', amount=to_nano('0.01', 'ton'), send_mode=3, payload='hello from python tonsdk')
+
+
+"""build and sign order with all required priv keys"""
+order1b = order1.build()
+order1b.sign(0, priv_k0)
+order1b.sign(1, priv_k1)
+
+query = wallet.create_transfer_message(order1b, priv_k2)
+transfer_boc = bytes_to_b64str(query["message"].to_boc(False))
+print('Base64boc to transfer tons: ', transfer_boc)

--- a/examples/wallets/multisig/onchain_signatures.py
+++ b/examples/wallets/multisig/onchain_signatures.py
@@ -1,0 +1,61 @@
+from tonsdk.tonsdk.contract.wallet import MultiSigWallet, MultiSigOrder, MultiSigOrderBuilder
+from tonsdk.tonsdk.crypto import mnemonic_new, mnemonic_to_wallet_key, verify_sign
+from tonsdk.tonsdk.utils import Address, bytes_to_b64str, b64str_to_bytes, to_nano, sign_message
+
+
+"""import or generate mnemonics"""
+# mnemonics1 = mnemonic_new()
+# mnemonics2 = mnemonic_new()
+# mnemonics3 = mnemonic_new()
+mnemonics1 = ['broken', 'decade', 'unit', 'bird', 'enrich', 'great', 'nurse', 'offer', 'rescue', 'sound', 'pole', 'true', 'dignity', 'buyer', 'provide', 'boil', 'connect', 'universe', 'model', 'add', 'obtain', 'hire', 'gift', 'swim']
+mnemonics2 = ['rather', 'voice', 'zone', 'fold', 'rotate', 'crane', 'roast', 'brave', 'motor', 'kid', 'note', 'squirrel', 'piece', 'home', 'expose', 'bench', 'flame', 'wood', 'person', 'assist', 'vocal', 'bomb', 'dismiss', 'diesel']
+mnemonics3 = ['author', 'holiday', 'figure', 'luxury', 'leg', 'fringe', 'sibling', 'citizen', 'enforce', 'convince', 'silly', 'girl', 'remove', 'purity', 'sand', 'paper', 'file', 'review', 'window', 'kite', 'illegal', 'allow', 'satisfy', 'wait']
+
+
+"""get pub and priv keys from mnemonics"""
+pub_k0, priv_k0 = mnemonic_to_wallet_key(mnemonics1)
+pub_k1, priv_k1 = mnemonic_to_wallet_key(mnemonics2)
+pub_k2, priv_k2 = mnemonic_to_wallet_key(mnemonics3)
+
+
+wallet = MultiSigWallet(public_keys=[pub_k0, pub_k1, pub_k2], k=2, wallet_id=0)
+
+
+"""create order and add message"""
+order1 = MultiSigOrderBuilder(wallet.options["wallet_id"])
+message = order1.add_message(to_addr='EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N', amount=to_nano('0.01', 'ton'), send_mode=3, payload='hello from python tonsdk')
+query_id = order1.query_id  # remember this query id or share this with other owners
+
+
+"""build and sign order"""
+order1b = order1.build()
+order1b.sign(0, priv_k0)
+
+
+"""send boc to blockchain"""
+query = wallet.create_transfer_message(order1b, priv_k0)
+transfer_boc = bytes_to_b64str(query["message"].to_boc(False))
+
+
+"""wait for transaction processing"""
+
+
+"""create second order with query id from first step"""
+order2 = MultiSigOrderBuilder(wallet.options["wallet_id"], query_id=query_id)
+
+
+"""add the same message here"""
+order2.add_message(to_addr='EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N', amount=to_nano('0.01', 'ton'),
+                   send_mode=3, payload='hello from python tonsdk')
+# or
+order2.add_message_from_cell(message)
+
+
+"""build and sign order"""
+order2b = order2.build()
+order2b.sign(1, priv_k1)
+
+
+"""send boc to blockchain"""
+query_2 = wallet.create_transfer_message(order2b, priv_k1)
+transfer_boc_2 = bytes_to_b64str(query_2["message"].to_boc(False))

--- a/examples/wallets/wallet.py
+++ b/examples/wallets/wallet.py
@@ -1,0 +1,35 @@
+from tonsdk.crypto import mnemonic_new
+from tonsdk.contract.wallet import Wallets, WalletVersionEnum
+from tonsdk.utils import to_nano, bytes_to_b64str
+
+
+mnemonics = ['broken', 'decade', 'unit', 'bird', 'enrich', 'great', 'nurse', 'offer', 'rescue',
+             'sound', 'pole', 'true', 'dignity', 'buyer', 'provide', 'boil', 'connect', 'universe',
+             'model', 'add', 'obtain', 'hire', 'gift', 'swim']
+#  mnemonics = mnemonic_new()
+version = WalletVersionEnum.v3r2
+wc = 0
+
+mnemonics, pub_k, priv_k, wallet = Wallets.from_mnemonics(mnemonics=mnemonics, version=version, workchain=wc)
+
+
+"""to external deploy"""
+boc = wallet.create_init_external_message()
+
+
+"""to internal deploy"""
+query = my_wallet.create_transfer_message(to_addr=new_wallet.address.to_string(),
+                                  amount=to_nano(0.02, 'ton'),
+                                  state_init=new_wallet.create_state_init()['state_init'],
+                                  seqno=int('wallet seqno'))
+
+
+"""transfer"""
+query = wallet.create_transfer_message(to_addr='destination address',
+                                  amount=to_nano(float('amount to transfer'), 'ton'),
+                                  payload='message',
+                                  seqno=int('wallet seqno'))
+
+
+"""then send boc to blockchain"""
+boc = bytes_to_b64str(query["message"].to_boc(False))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tonsdk
-version = 1.0.11
+version = 1.0.12
 description = Python SDK for TON
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tonsdk/boc/_bit_string.py
+++ b/tonsdk/boc/_bit_string.py
@@ -1,5 +1,7 @@
 import copy
 import math
+from typing import Union, Optional
+
 from ..utils._address import Address
 
 
@@ -100,7 +102,7 @@ class BitString:
         for b in ba.decode('utf-8'):
             self.write_bit(b)
 
-    def write_bit(self, b: str | int):
+    def write_bit(self, b: Union[str, int]):
         b = int(b)
         if b == 1:
             self.on(self.cursor)
@@ -162,7 +164,7 @@ class BitString:
         for bit in another_bit_string:
             self.write_bit(bit)
 
-    def write_address(self, address: Address | None):
+    def write_address(self, address: Optional[Address]):
         """Writes an address, maybe zero-address (None) to the BitString."""
         if address is None:
             self.write_uint(0, 2)

--- a/tonsdk/boc/_cell.py
+++ b/tonsdk/boc/_cell.py
@@ -165,6 +165,10 @@ class Cell:
 
         return ser_arr
 
+    def begin_parse(self):
+        from ._slice import Slice
+        return Slice(self)
+
     @staticmethod
     def one_from_boc(serialized_boc):
         cells = deserialize_boc(serialized_boc)

--- a/tonsdk/boc/_slice.py
+++ b/tonsdk/boc/_slice.py
@@ -87,7 +87,7 @@ class Slice:
             return None
         self.read_bit()  # anycast
         workchain_id = hex(self.read_int(8))[2:]
-        hashpart = hex(self.read_uint(256))[2:]
+        hashpart = self.read_bytes(32).hex()
         return Address(workchain_id + ":" + hashpart)
 
     def read_coins(self) -> int:

--- a/tonsdk/boc/_slice.py
+++ b/tonsdk/boc/_slice.py
@@ -1,4 +1,6 @@
 import bitarray
+from typing import Optional
+
 from ._cell import Cell
 from ..utils._address import Address
 
@@ -80,7 +82,7 @@ class Slice:
         self.bits = tmp
         return value
 
-    def read_msg_addr(self) -> Address | None:
+    def read_msg_addr(self) -> Optional[Address]:
         """Reads contract address from the slice.
         May return None if there is a zero-address."""
         if self.read_uint(2) == 0:
@@ -118,7 +120,7 @@ class Slice:
     def preload_ref(self) -> Cell:
         return self.refs[self.ref_offset]
 
-    def load_dict(self) -> Cell | None:
+    def load_dict(self) -> Optional[Cell]:
         """Loads dictionary like a Cell from the slice.
         Returns None if the dictionary was null()."""
         not_null = self.read_bit()
@@ -127,7 +129,7 @@ class Slice:
         else:
             return None
 
-    def preload_dict(self) -> Cell | None:
+    def preload_dict(self) -> Optional[Cell]:
         not_null = self.preload_bit()
         if not_null:
             return self.preload_ref()

--- a/tonsdk/contract/token/nft/nft_collection.py
+++ b/tonsdk/contract/token/nft/nft_collection.py
@@ -1,4 +1,5 @@
 from math import floor
+from typing import List, Tuple
 
 from .nft_utils import create_offchain_uri_cell, serialize_uri
 from ... import Contract
@@ -63,7 +64,7 @@ class NFTCollection(Contract):
     
     def create_batch_mint_body(
             self, from_item_index: int,
-            contents_and_owners: list[tuple[str, Address]],
+            contents_and_owners: List[Tuple[str, Address]],
             amount_per_one: int = 50000000, query_id: int = 0
     ) -> Cell:
         body = Cell()

--- a/tonsdk/contract/wallet/_wallet_contract.py
+++ b/tonsdk/contract/wallet/_wallet_contract.py
@@ -1,5 +1,6 @@
 import decimal
 from enum import Enum
+from typing import Union
 
 from .. import Contract
 from ...boc import Cell
@@ -40,16 +41,15 @@ class WalletContract(Contract):
                                 to_addr: str,
                                 amount: int,
                                 seqno: int,
-                                payload: Cell | str | bytes | None = None,
+                                payload: Union[Cell, str, bytes, None] = None,
                                 send_mode=SendModeEnum.ignore_errors | SendModeEnum.pay_gas_separately,
                                 dummy_signature=False, state_init=None):
         payload_cell = Cell()
         if payload:
-            t = type(payload)
-            if t == str:
+            if isinstance(payload, str):
                 payload_cell.bits.write_uint(0, 32)
                 payload_cell.bits.write_string(payload)
-            elif t == Cell:
+            elif isinstance(payload, Cell):
                 payload_cell = payload
             else:
                 payload_cell.bits.write_bytes(payload)


### PR DESCRIPTION
it's dangerous to use `read_uint()` to get hashpart because `int()` discards leading zeros.

for e.g try this code 
```python
from tonsdk.boc import begin_cell, Slice
from tonsdk.contract import Address

msg = begin_cell().store_address(Address('EQAK_N6mCt6yRIcGodXLACmEgyO1RkbI9BrlOJtwjM9FVz5Q')).end_cell()

slice = Slice(msg)
slice.read_msg_addr()
"""
tonsdk.utils._exceptions.InvalidAddressError: Invalid address hex 0:afcdea60adeb2448706a1d5cb0029848323b54646c8f41ae5389b708ccf4557
"""

```
that's because
 ```python
 hex(self.read_uint(256))[2:]
```

returned `afcdea60adeb2448706a1d5cb0029848323b54646c8f41ae5389b708ccf4557` 
instead of `0afcdea60adeb2448706a1d5cb0029848323b54646c8f41ae5389b708ccf4557 `